### PR TITLE
fix: Dockerfile base 이미지 교체로 CD 빌드 오류 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN gradle dependencies --no-daemon || return 0
 COPY src src
 RUN gradle bootJar --no-daemon
 
-# 2단계: 실행 환경 (JRE만 포함, 훨씬 가벼움)
-FROM openjdk:17-jdk-slim
+# 2단계: 실행 환경
+FROM eclipse-temurin:17-jdk-jammy
 ENV TZ=Asia/Seoul
 RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul"


### PR DESCRIPTION
## 🎋 관련 이슈
- CD 빌드 실패 (openjdk 이미지 미존재로 인한 오류)

## ⚡️ 작업동기
- GitHub Actions CD 파이프라인에서 `openjdk:17-jdk-slim` 이미지를 찾지 못해  
  Docker 빌드가 중단되는 문제가 발생하였음.  
- 최신 안정 이미지(`eclipse-temurin:17-jdk-jammy`)로 교체하여  
  빌드 및 배포를 정상화하기 위함.

## 🔑 주요 변경사항
- Dockerfile의 실행 단계(base image)를 `openjdk:17-jdk-slim` → `eclipse-temurin:17-jdk-jammy` 로 변경  
- 기존 slim 이미지 삭제 대응 및 Java 17 런타임 환경 유지  
- CD 파이프라인에서 빌드 오류 방지

## 💡 유의사항 또는 기타
- CI/CD 실행 후 Docker 빌드 성공 여부를 Actions 탭에서 반드시 확인  
- 추후 `amazoncorretto:17-alpine` 전환 검토 가능 (경량 배포용)

## ✅ Check List
- [x] **Reviewers** 등록을 하였나요?  
- [x] **Assignees** 등록을 하였나요?  
- [x] **라벨(Label)** 등록을 하였나요?  
- [x] PR 머지하기 전 반드시 **CI/CD 빌드가 정상적으로 작동하는지 확인**해주세요!  
