### PR TITLE
feat: 여러 태그 필터링 기능 구현 (OR 조건 + 커서 페이지네이션 지원)

### DIFF
--- a/src/main/java/com/example/momentory/domain/community/controller/PostController.java
+++ b/src/main/java/com/example/momentory/domain/community/controller/PostController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/community/posts")
@@ -62,6 +63,20 @@ public class PostController {
             @RequestParam(defaultValue = "20") Integer size) {
         PostRequestDto.PostCursorRequest req = new PostRequestDto.PostCursorRequest(cursor, size);
         return ApiResponse.onSuccess(postQueryService.getPostsByTag(tagName, req));
+    }
+
+    @GetMapping("/tags/filter")
+    @Operation(summary = "다중 태그 필터링", description = "여러 태그로 게시글을 필터링합니다. (OR 조건)")
+    public ApiResponse<PostResponseDto.PostCursorResponse> getPostsByTags(
+            @RequestParam List<String> tags,
+            @RequestParam(required = false) LocalDateTime cursor,
+            @RequestParam(defaultValue = "20") Integer size) {
+        PostRequestDto.PostTagFilterRequest req = PostRequestDto.PostTagFilterRequest.builder()
+                .tags(tags)
+                .cursor(cursor)
+                .size(size)
+                .build();
+        return ApiResponse.onSuccess(postQueryService.getPostsByTags(req));
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/example/momentory/domain/community/dto/PostRequestDto.java
+++ b/src/main/java/com/example/momentory/domain/community/dto/PostRequestDto.java
@@ -45,4 +45,15 @@ public class PostRequestDto {
         private LocalDateTime cursor; // 마지막으로 조회한 게시글의 createdAt
         private Integer size; // 조회할 게시글 개수
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostTagFilterRequest {
+        private List<String> tags; // 필터링할 태그 리스트
+        private LocalDateTime cursor; // 마지막으로 조회한 게시글의 createdAt
+        private Integer size; // 조회할 게시글 개수
+    }
 }

--- a/src/main/java/com/example/momentory/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/example/momentory/domain/community/repository/PostRepository.java
@@ -67,4 +67,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 검색 첫 페이지
     @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword% ORDER BY p.createdAt DESC")
     List<Post> searchPostsOrderByCreatedAtDesc(@Param("keyword") String keyword, Pageable pageable);
+
+    // ===== 다중 태그 필터링 (OR 조건) =====
+
+    // 다중 태그 필터링 커서 페이지네이션
+    @Query("SELECT DISTINCT p FROM Post p JOIN p.postTags pt JOIN pt.tag t WHERE t.name IN :tagNames AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
+    List<Post> findAllByTagNamesWithCursor(@Param("tagNames") List<String> tagNames, @Param("cursor") LocalDateTime cursor, Pageable pageable);
+
+    // 다중 태그 필터링 첫 페이지
+    @Query("SELECT DISTINCT p FROM Post p JOIN p.postTags pt JOIN pt.tag t WHERE t.name IN :tagNames ORDER BY p.createdAt DESC")
+    List<Post> findAllByTagNamesOrderByCreatedAtDesc(@Param("tagNames") List<String> tagNames, Pageable pageable);
 }


### PR DESCRIPTION
## 🎋 관련 이슈

- #24 

## ⚡️ 작업동기

- 여러 태그를 동시에 선택해 게시글을 필터링할 수 있는 기능 필요성에 따라 구현하였습니다.  
- 기존 단일 태그 검색 기능의 한계를 보완하고, 커뮤니티 내 관심사 기반 탐색 효율을 높이기 위함입니다.

## 🔑 주요 변경사항

- `PostController`  
  - `/api/community/posts/tags/filter` 엔드포인트 추가  
  - 여러 태그로 게시글을 OR 조건 필터링하도록 구현  

- `PostRequestDto`  
  - `PostTagFilterRequest` DTO 추가 (`tags`, `cursor`, `size` 포함)

- `PostRepository`  
  - 다중 태그 필터링 JPQL 쿼리 추가 (커서 기반 페이지네이션 지원)  
  - `findAllByTagNamesOrderByCreatedAtDesc`, `findAllByTagNamesWithCursor` 메서드 추가  

- `PostQueryService`  
  - 다중 태그 필터링 로직 추가  
  - 첫 페이지 / 커서 이후 조회 로직 분기 처리  
  - 응답 시 `nextCursor`, `hasNext` 포함  

## 💡 유의사항 또는 기타

- 다중 태그 필터링은 OR 조건으로 작동합니다. (즉, 입력한 태그 중 하나라도 포함되면 조회)  
- 커서 기반 페이지네이션 적용되어 있어 무한스크롤 시에도 안정적으로 동작합니다.

## ✅ Check List

- [ ] **Reviewers** 등록을 하였나요?  
- [ ] **Assignees** 등록을 하였나요?  
- [ ] **라벨(Label)** 등록을 하였나요?  
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
