### PR TITLE
fix: 상점 아이템 전체 조회로 변경하고 unlockLevel 기준 정렬 적용

### DIFF
--- a/src/main/java/com/example/momentory/domain/character/repository/CharacterItemRepository.java
+++ b/src/main/java/com/example/momentory/domain/character/repository/CharacterItemRepository.java
@@ -14,6 +14,8 @@ public interface CharacterItemRepository extends JpaRepository<CharacterItem, Lo
 
     List<CharacterItem> findAllByOrderByPriceAsc();
 
+    List<CharacterItem> findAllByOrderByUnlockLevelAsc();
+
     List<CharacterItem> findTop3ByOrderByCreatedAtDesc();
 }
 

--- a/src/main/java/com/example/momentory/domain/character/service/ShopService.java
+++ b/src/main/java/com/example/momentory/domain/character/service/ShopService.java
@@ -38,15 +38,10 @@ public class ShopService {
         User user = userService.getCurrentUser();
         LocalDateTime now = LocalDateTime.now();
 
-        // 현재 캐릭터의 레벨 확인
-        Character currentCharacter = characterService.getCurrentCharacter();
-        int currentLevel = currentCharacter.getLevel();
-
-        // 모든 아이템 조회 후 필터링
-        List<CharacterItem> allItems = characterItemRepository.findAllByOrderByPriceAsc();
+        // 모든 아이템을 unlockLevel 오름차순으로 조회
+        List<CharacterItem> allItems = characterItemRepository.findAllByOrderByUnlockLevelAsc();
 
         return allItems.stream()
-                .filter(item -> item.getUnlockLevel() <= currentLevel) // 레벨 제한 필터링
                 .filter(item -> category == null || item.getCategory() == category) // 카테고리 필터링
                 .filter(item -> isItemAvailable(item, now)) // 이벤트 아이템 기간 검증
                 .map(item -> {


### PR DESCRIPTION
## 🎋 관련 이슈

#40 

---

## ⚡️ 작업동기  
기존 상점 아이템 조회는 **사용자 레벨 이하의 아이템만 조회**하도록 되어 있어,  
상점 전체 아이템을 보여주는 요구사항과 맞지 않는 문제가 있었습니다.  
이에 따라 **전체 아이템 조회 + unlockLevel 기준 정렬**로 변경했습니다.

---

## 🔑 주요 변경사항  
- 기존: `unlockLevel <= currentLevel` 조건으로 필터링  
- 변경: **전체 아이템 조회로 수정 (레벨 제한 제거)**  
- 정렬 기준 변경: `findAllByOrderByPriceAsc()` → `findAllByOrderByUnlockLevelAsc()`  
- Repository에 새 정렬 메서드 추가  
- 캐릭터 레벨 조회 및 관련 로직 제거  
- 카테고리 필터 및 이벤트 기간 필터는 기존대로 유지

---

## 💡 유의사항 또는 기타  
- 이벤트 기간이 지난 아이템은 기존 로직대로 제외됩니다.  
- 카테고리(category) 파라미터는 그대로 필터링에 적용됩니다.

---

## ✅ Check List  
- [x] **Reviewers** 등록을 하였나요?  
- [x] **Assignees** 등록을 하였나요?  
- [x] **라벨(Label)** 등록을 하였나요?  
- [x] PR 머지 전 **CI 정상 작동 여부** 확인했나요?